### PR TITLE
Expand redacting capabilities

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,8 @@ class User < ApplicationRecord
 end
 ```
 ### Redactor Types
+
+#### Built in
 `redaction` comes with a few different redactor types:
 | Type         | Generates    |
 |:------------:|:------------:|
@@ -41,6 +43,33 @@ end
 | `:html`      | Multiple HTML Paragraphs with a random amount of link tags, `strong` tags, and `em` tags  |
 | `:name`      | A person first/last name |
 | `:text`      | Multiple paragraphs |
+
+#### Using a Proc
+A Proc `:with` value is given two arguments: the record being redacted, and a hash with the :attribute key-value pair.
+```ruby
+class Model < ApplicationRecord
+  redacts :attribute, with: -> (record, data) { record.id }
+end
+```
+would cause `Model#attribute` to be set to `Model#id` after redaction
+#### Using a custom class
+Add a folder in `app/`, `redactors/` is suggested, and put custom redactors in there. A custom redactor should inherit from `Redaction::Types::Base` and should define a `content` method. Like so:
+```ruby
+# app/redactors/custom_redactor.rb
+class CustomRedactor < Redaction::Types::Base
+  def content
+    "Some Custom Value"
+  end
+end
+```
+and then to use it:
+```ruby
+class Model < ApplicationRecord
+  redacts :attribute, with: CustomRedactor
+end
+```
+would cause `Model#attribute` to be set to "Some Custom Value" after redaction.
+Custom redactor types also get access to the record being redacted via `record`, and a hash with the `:attribute` key-value pair via `data`
 
 ### Preforming a Redaction
 There are two ways to preform the redaction.

--- a/lib/redaction.rb
+++ b/lib/redaction.rb
@@ -16,7 +16,11 @@ module Redaction
   autoload :Redactor, "redaction/redactor"
 
   def self.find(redactor_type)
-    "Redaction::Types::#{redactor_type.to_s.camelize}".constantize.new
+    if redactor_type.respond_to?(:call)
+      redactor_type
+    else
+      "Redaction::Types::#{redactor_type.to_s.camelize}".safe_constantize || Redaction::Types::Base
+    end
   end
 
   def self.redactable_models

--- a/lib/redaction.rb
+++ b/lib/redaction.rb
@@ -3,6 +3,7 @@ require "redaction/railtie"
 
 module Redaction
   module Types
+    autoload :Base, "redaction/types/base"
     autoload :Basic, "redaction/types/basic"
     autoload :BasicHtml, "redaction/types/basic_html"
     autoload :Email, "redaction/types/email"

--- a/lib/redaction/redactable.rb
+++ b/lib/redaction/redactable.rb
@@ -16,7 +16,7 @@ module Redaction
 
           attributes.each do |attribute|
             if send(attribute).present?
-              send("#{attribute}=", redactor.redact)
+              send("#{attribute}=", redactor.call(self))
             end
           end
         end

--- a/lib/redaction/redactable.rb
+++ b/lib/redaction/redactable.rb
@@ -16,12 +16,12 @@ module Redaction
 
           attributes.each do |attribute|
             if send(attribute).present?
-              send("#{attribute}=", redactor.call(self))
+              send("#{attribute}=", redactor.call(self, { attribute: attribute }))
             end
           end
         end
 
-        save(validate: false, touch: false, context: :redaction)
+        save!(validate: false, touch: false, context: :redaction)
       end
 
       def redacting?

--- a/lib/redaction/types/base.rb
+++ b/lib/redaction/types/base.rb
@@ -1,0 +1,13 @@
+module Redaction
+  module Types
+    class Base
+      def self.call(*args)
+        content
+      end
+
+      def self.content
+        "[REDACTED]"
+      end
+    end
+  end
+end

--- a/lib/redaction/types/base.rb
+++ b/lib/redaction/types/base.rb
@@ -1,11 +1,18 @@
 module Redaction
   module Types
     class Base
-      def self.call(*args)
-        content
+      attr_reader :record, :data
+
+      def self.call(record, data)
+        new(record, data).content
       end
 
-      def self.content
+      def initialize(record, data)
+        @record = record
+        @data = data
+      end
+
+      def content
         "[REDACTED]"
       end
     end

--- a/lib/redaction/types/basic.rb
+++ b/lib/redaction/types/basic.rb
@@ -3,7 +3,7 @@ require "faker"
 module Redaction
   module Types
     class Basic < Base
-      def self.content
+      def content
         Faker::Lorem.sentence(word_count: rand(3..10)).gsub(/\.$/, "")
       end
     end

--- a/lib/redaction/types/basic.rb
+++ b/lib/redaction/types/basic.rb
@@ -2,8 +2,8 @@ require "faker"
 
 module Redaction
   module Types
-    class Basic
-      def redact
+    class Basic < Base
+      def self.content
         Faker::Lorem.sentence(word_count: rand(3..10)).gsub(/\.$/, "")
       end
     end

--- a/lib/redaction/types/basic_html.rb
+++ b/lib/redaction/types/basic_html.rb
@@ -2,8 +2,8 @@ require "faker"
 
 module Redaction
   module Types
-    class BasicHtml
-      def redact
+    class BasicHtml < Base
+      def self.content
         [nil, "em", "strong"].shuffle.map! do |tag|
           text = Faker::Lorem.sentence(word_count: rand(1..3)).sub(/\.$/, "")
           tag ? "<#{tag}>#{text}</#{tag}>" : text

--- a/lib/redaction/types/basic_html.rb
+++ b/lib/redaction/types/basic_html.rb
@@ -3,7 +3,7 @@ require "faker"
 module Redaction
   module Types
     class BasicHtml < Base
-      def self.content
+      def content
         [nil, "em", "strong"].shuffle.map! do |tag|
           text = Faker::Lorem.sentence(word_count: rand(1..3)).sub(/\.$/, "")
           tag ? "<#{tag}>#{text}</#{tag}>" : text

--- a/lib/redaction/types/email.rb
+++ b/lib/redaction/types/email.rb
@@ -2,8 +2,8 @@ require "faker"
 
 module Redaction
   module Types
-    class Email
-      def redact
+    class Email < Base
+      def self.content
         Faker::Internet.safe_email
       end
     end

--- a/lib/redaction/types/email.rb
+++ b/lib/redaction/types/email.rb
@@ -3,7 +3,7 @@ require "faker"
 module Redaction
   module Types
     class Email < Base
-      def self.content
+      def content
         Faker::Internet.safe_email
       end
     end

--- a/lib/redaction/types/html.rb
+++ b/lib/redaction/types/html.rb
@@ -8,10 +8,6 @@ module Redaction
       TAGS = %i[em strong a]
       private_constant :TAGS
 
-      def self.content
-        new.content
-      end
-
       def content
         1.upto(rand(1..3)).map { content_tag(:p, generate_paragraph.html_safe) }.join("\n")
       end

--- a/lib/redaction/types/html.rb
+++ b/lib/redaction/types/html.rb
@@ -2,13 +2,17 @@ require "faker"
 
 module Redaction
   module Types
-    class Html
+    class Html < Base
       include ActionView::Helpers::TagHelper
 
       TAGS = %i[em strong a]
       private_constant :TAGS
 
-      def redact
+      def self.content
+        new.content
+      end
+
+      def content
         1.upto(rand(1..3)).map { content_tag(:p, generate_paragraph.html_safe) }.join("\n")
       end
 

--- a/lib/redaction/types/name.rb
+++ b/lib/redaction/types/name.rb
@@ -2,8 +2,8 @@ require "faker"
 
 module Redaction
   module Types
-    class Name
-      def redact
+    class Name < Base
+      def self.content
         Faker::Name.first_name
       end
     end

--- a/lib/redaction/types/name.rb
+++ b/lib/redaction/types/name.rb
@@ -3,7 +3,7 @@ require "faker"
 module Redaction
   module Types
     class Name < Base
-      def self.content
+      def content
         Faker::Name.first_name
       end
     end

--- a/lib/redaction/types/text.rb
+++ b/lib/redaction/types/text.rb
@@ -3,7 +3,7 @@ require "faker"
 module Redaction
   module Types
     class Text < Base
-      def self.content
+      def content
         paragraphs = 1.upto(rand(1..3)).map do
           Faker::Lorem.paragraph(sentence_count: rand(1..5))
         end

--- a/lib/redaction/types/text.rb
+++ b/lib/redaction/types/text.rb
@@ -2,8 +2,8 @@ require "faker"
 
 module Redaction
   module Types
-    class Text
-      def redact
+    class Text < Base
+      def self.content
         paragraphs = 1.upto(rand(1..3)).map do
           Faker::Lorem.paragraph(sentence_count: rand(1..5))
         end

--- a/test/dummy/app/models/user.rb
+++ b/test/dummy/app/models/user.rb
@@ -3,6 +3,9 @@ class User < ApplicationRecord
   lockbox_encrypts :phone
 
   redacts :first_name, with: :name
+  redacts :middle_name, with: ->(record) { "#{record.model_name.human} #{record.id}" }
+  redacts :suffix, with: :missing
+  redacts :username, with: Custom
   redacts :email, with: :email
   redacts :ssn, :phone
 end

--- a/test/dummy/app/models/user.rb
+++ b/test/dummy/app/models/user.rb
@@ -5,7 +5,7 @@ class User < ApplicationRecord
   redacts :first_name, with: :name
   redacts :middle_name, with: ->(record) { "#{record.model_name.human} #{record.id}" }
   redacts :suffix, with: :missing
-  redacts :username, with: Custom
+  redacts :username, with: CustomRedactor
   redacts :email, with: :email
   redacts :ssn, :phone
 end

--- a/test/dummy/app/models/user.rb
+++ b/test/dummy/app/models/user.rb
@@ -3,7 +3,7 @@ class User < ApplicationRecord
   lockbox_encrypts :phone
 
   redacts :first_name, with: :name
-  redacts :middle_name, with: ->(record) { "#{record.model_name.human} #{record.id}" }
+  redacts :middle_name, with: ->(record, data) { "#{record.model_name.human} #{record.id}" }
   redacts :suffix, with: :missing
   redacts :username, with: CustomRedactor
   redacts :email, with: :email

--- a/test/dummy/app/redactors/custom.rb
+++ b/test/dummy/app/redactors/custom.rb
@@ -1,0 +1,5 @@
+class Custom < Redaction::Types::Base
+  def self.content
+    "I'm a custom redactor"
+  end
+end

--- a/test/dummy/app/redactors/custom_redactor.rb
+++ b/test/dummy/app/redactors/custom_redactor.rb
@@ -1,5 +1,5 @@
 class CustomRedactor < Redaction::Types::Base
-  def self.content
+  def content
     "I'm a custom redactor"
   end
 end

--- a/test/dummy/app/redactors/custom_redactor.rb
+++ b/test/dummy/app/redactors/custom_redactor.rb
@@ -1,4 +1,4 @@
-class Custom < Redaction::Types::Base
+class CustomRedactor < Redaction::Types::Base
   def self.content
     "I'm a custom redactor"
   end

--- a/test/dummy/db/schema.rb
+++ b/test/dummy/db/schema.rb
@@ -33,7 +33,10 @@ ActiveRecord::Schema.define(version: 2022_03_09_194044) do
 
   create_table "users", force: :cascade do |t|
     t.string "first_name"
+    t.string "middle_name"
     t.string "last_name"
+    t.string "suffix"
+    t.string "username"
     t.string "email"
     t.string "encrypted_ssn"
     t.string "encrypted_ssn_iv"

--- a/test/fixtures/users.yml
+++ b/test/fixtures/users.yml
@@ -2,10 +2,16 @@
 
 one:
   first_name: FirstName
+  middle_name: MiddleName
   last_name: LastName
+  suffix: Sr.
+  username: user-name1
   email: one@example.com
 
 two:
   first_name: FirstName
+  middle_name: MiddleName
   last_name: LastName
+  suffix: Jr.
+  username: user-name2
   email: two@example.com

--- a/test/redaction_test.rb
+++ b/test/redaction_test.rb
@@ -6,6 +6,30 @@ class RedactionTest < ActiveSupport::TestCase
     assert Redaction::VERSION
   end
 
+  test "it accepts a proc as a redactor" do
+    user = users(:one)
+    user.redact!
+
+    assert_not_equal user.middle_name, "MiddleName"
+    assert_equal user.middle_name, "User #{user.id}"
+  end
+
+  test "it accepts a Class as a redactor" do
+    user = users(:one)
+    user.redact!
+
+    assert_not_equal user.username, "user-name1"
+    assert_equal user.username, "I'm a custom redactor"
+  end
+
+  test "it defaults to '[REDACTED]' when redactor type can't be found" do
+    user = users(:one)
+    user.redact!
+
+    assert_not_equal user.suffix, "Sr."
+    assert_equal user.suffix, "[REDACTED]"
+  end
+
   test "it only redacts specified attributes" do
     user = users(:one)
     user.redact!


### PR DESCRIPTION
# Expand redacting capabilities
Adjusts the way `Types` work under the hood to allow for `proc` or custom classes to be passed as the redactor.  Adds a `Base` Type to serve as the default type and as a super class.
## Using a Proc
A Proc `:with` value is given two arguments: the record being redacted, and a hash with the :attribute key-value pair.
```ruby
class Model < ApplicationRecord
  redacts :attribute, with: -> (record, data) { record.id }
end
```
would cause `Model#attribute` to be set to `Model#id` after redaction
## Using a custom class
Add a folder in `app/`, `redactors/` is suggested, and put custom redactors in there. A custom redactor should inherit from `Redaction::Types::Base` and should define a `content` method. Like so:
```ruby
# app/redactors/custom_redactor.rb
class CustomRedactor < Redaction::Types::Base
  def content
    "Some Custom Value"
  end
end
```
and then to use it:
```ruby
class Model < ApplicationRecord
  redacts :attribute, with: CustomRedactor
end
```
would cause `Model#attribute` to be set to "Some Custom Value" after redaction. Custom redactor types also gets access to the record being redacted via `record`, and a hash with the :attribute key-value pair via `data`