### PR TITLE
Improve performing a redaction

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,11 +92,11 @@ This will only redact the `User` and `Post` Models
 
 #### Via the Rails Console
 ```ruby
-Redaction::Redactor.new.redact
+Redaction.redact!
 ```
 This will target **all** the models with redacted attributes. To target specific models run:
 ```ruby
-Redaction::Redactor.new(models: ["User", "Post"]).redact
+Redaction.redact!(models: ["User", "Post"])
 ```
 This will only redact the `User` and `Post` Models
 

--- a/lib/redaction.rb
+++ b/lib/redaction.rb
@@ -26,4 +26,8 @@ module Redaction
   def self.redactable_models
     ApplicationRecord.subclasses.select { |descendant| descendant.has_redacted_content? }
   end
+
+  def self.redact!(models: nil)
+    Redactor.new(models: models).redact!
+  end
 end

--- a/lib/redaction/redactable.rb
+++ b/lib/redaction/redactable.rb
@@ -16,7 +16,7 @@ module Redaction
 
           attributes.each do |attribute|
             if send(attribute).present?
-              send("#{attribute}=", redactor.call(self, { attribute: attribute }))
+              send("#{attribute}=", redactor.call(self, {attribute: attribute}))
             end
           end
         end

--- a/lib/redaction/redactor.rb
+++ b/lib/redaction/redactor.rb
@@ -8,7 +8,7 @@ module Redaction
       @models_to_redact = set_models(models)
     end
 
-    def redact
+    def redact!
       models_to_redact.each do |model|
         next if model.redacted_attributes.empty?
 

--- a/lib/tasks/redaction.rake
+++ b/lib/tasks/redaction.rake
@@ -10,6 +10,6 @@ namespace :redaction do
     model_names = (ENV["MODELS"] || "").split(",").map(&:strip)
     puts model_names.empty? ? "Redacting all models" : "Redacting models: #{model_names.join(", ")}"
 
-    Redaction::Redactor.new(models: model_names).redact
+    Redaction.redact!(models: model_names)
   end
 end

--- a/test/redaction_test.rb
+++ b/test/redaction_test.rb
@@ -124,7 +124,7 @@ class RedactionTest < ActiveSupport::TestCase
     user = users(:one)
     post = posts(:one)
 
-    Redaction::Redactor.new.redact
+    Redaction.redact!
 
     assert_not_equal comment.content, comment.reload.content
     assert_not_equal user.email, user.reload.email
@@ -136,7 +136,7 @@ class RedactionTest < ActiveSupport::TestCase
     user = users(:one)
     post = posts(:one)
 
-    Redaction::Redactor.new(models: ["Comment", "User"]).redact
+    Redaction.redact!(models: ["Comment", "User"])
 
     assert_not_equal comment.content, comment.reload.content
     assert_not_equal user.email, user.reload.email


### PR DESCRIPTION
Both Andrew Mason and Dana Kashubeck gave the feedback that they felt it made more sense to have a method on the `Redaction` module to handle performing the redaction.  Rather than creating a new `Redactor`. The "preferred" way of performing a redaction via the console will now be:
```ruby
Redaction.redact!
```
to target all models or:
```ruby
Redaction.redact!(models: ["Model", "Model"])
```
to target models.

The included rake task is also updated. Technically `Redaction::Redactor.new.redact` still works since that's what `Redaction.redact!` calls under the hood.  It's just no longer the preferred method to call.