### PR TITLE
Add phone number type

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,7 @@ end
 | `:email`     | A safe (will not send) email address |
 | `:html`      | Multiple HTML Paragraphs with a random amount of link tags, `strong` tags, and `em` tags  |
 | `:name`      | A person first/last name |
+| `:phone`     | A phone number |
 | `:text`      | Multiple paragraphs |
 
 To use a built in redactor type set the `with:` option of a `redacts` call to the appropriate symbol.

--- a/lib/redaction.rb
+++ b/lib/redaction.rb
@@ -9,6 +9,7 @@ module Redaction
     autoload :Email, "redaction/types/email"
     autoload :Html, "redaction/types/html"
     autoload :Name, "redaction/types/name"
+    autoload :Phone, "redaction/types/phone"
     autoload :Text, "redaction/types/text"
   end
 

--- a/lib/redaction/types/phone.rb
+++ b/lib/redaction/types/phone.rb
@@ -1,0 +1,13 @@
+require "faker"
+
+module Redaction
+  module Types
+    class Phone < Base
+      def content
+        # Use cell_phone so no extension is added
+        # see: https://github.com/faker-ruby/faker/blob/master/doc/default/phone_number.md
+        Faker::PhoneNumber.cell_phone
+      end
+    end
+  end
+end

--- a/test/dummy/app/models/account.rb
+++ b/test/dummy/app/models/account.rb
@@ -1,0 +1,5 @@
+class Account < ApplicationRecord
+  belongs_to :user
+
+  redacts :phone_number, with: :phone
+end

--- a/test/dummy/db/schema.rb
+++ b/test/dummy/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2022_04_01_163109) do
+ActiveRecord::Schema.define(version: 2022_04_01_163109) do
   create_table "accounts", force: :cascade do |t|
     t.integer "user_id", null: false
     t.string "phone_number"

--- a/test/dummy/db/schema.rb
+++ b/test/dummy/db/schema.rb
@@ -10,7 +10,15 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_03_09_194044) do
+ActiveRecord::Schema[7.0].define(version: 2022_04_01_163109) do
+  create_table "accounts", force: :cascade do |t|
+    t.integer "user_id", null: false
+    t.string "phone_number"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["user_id"], name: "index_accounts_on_user_id"
+  end
+
   create_table "comments", force: :cascade do |t|
     t.integer "post_id", null: false
     t.integer "user_id", null: false
@@ -45,6 +53,7 @@ ActiveRecord::Schema.define(version: 2022_03_09_194044) do
     t.datetime "updated_at", precision: nil, null: false
   end
 
+  add_foreign_key "accounts", "users"
   add_foreign_key "comments", "posts"
   add_foreign_key "comments", "users"
   add_foreign_key "posts", "users"

--- a/test/fixtures/accounts.yml
+++ b/test/fixtures/accounts.yml
@@ -1,0 +1,9 @@
+# Read about fixtures at https://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+
+one:
+  user: one
+  phone_number: (111) 111-1111
+
+two:
+  user: two
+  phone_number: (111) 111-1111

--- a/test/redaction_test.rb
+++ b/test/redaction_test.rb
@@ -194,4 +194,12 @@ class RedactionTest < ActiveSupport::TestCase
 
     assert_not_equal user.phone, "(111) 111-1111"
   end
+
+  test "it generates a redacted phone number" do
+    account = accounts(:one)
+    account.redact!
+
+    assert_not_equal "(111) 111-1111", account.phone_number
+    assert_match(/\d?.?\(?\d{3}\)?\s?.?\d{3}.?\d{4}/, account.phone_number)
+  end
 end


### PR DESCRIPTION
Adds ability to do:
```ruby
redacts :phone_number, with: :phone
```
This redactor type will  return one of the following formats:

- 333-333-3333
- (333) 333-3333
- 1-333-333-3333
- 333.333.3333

See [Faker.cell_phone](https://github.com/faker-ruby/faker/blob/master/doc/default/phone_number.md#cell_phone) for more information.