### PR TITLE
feat: Add ability to customize redacted email domains

### DIFF
--- a/lib/redaction/railtie.rb
+++ b/lib/redaction/railtie.rb
@@ -4,6 +4,7 @@ module Redaction
       @config ||= Railtie.config.redaction
     end
   end
+
   class Railtie < ::Rails::Railtie
     config.redaction = ActiveSupport::OrderedOptions.new
 

--- a/lib/redaction/railtie.rb
+++ b/lib/redaction/railtie.rb
@@ -1,6 +1,17 @@
 module Redaction
+  class << self
+    def config
+      @config ||= Railtie.config.redaction
+    end
+  end
   class Railtie < ::Rails::Railtie
+    config.redaction = ActiveSupport::OrderedOptions.new
+
     initializer "redaction.initialize" do
+      options = config.redaction
+
+      options.email_domain = options.email_domain
+
       ActiveSupport.on_load(:active_record) do
         include Redaction::Redactable
       end

--- a/lib/redaction/types/email.rb
+++ b/lib/redaction/types/email.rb
@@ -4,7 +4,11 @@ module Redaction
   module Types
     class Email < Base
       def content
-        Faker::Internet.safe_email
+        if Redaction.config.email_domain.present?
+          Faker::Internet.email(domain: Redaction.config.email_domain)
+        else
+          Faker::Internet.safe_email
+        end
       end
     end
   end

--- a/test/redaction_test.rb
+++ b/test/redaction_test.rb
@@ -202,4 +202,15 @@ class RedactionTest < ActiveSupport::TestCase
     assert_not_equal "(111) 111-1111", account.phone_number
     assert_match(/\d?.?\(?\d{3}\)?\s?.?\d{3}.?\d{4}/, account.phone_number)
   end
+
+  test "it generates a redacted email with a specific domain if configured" do
+    Redaction.config.email_domain = "special.com"
+
+    user = users(:one)
+    user.redact!
+
+    Redaction.config.email_domain = nil # Reset
+
+    assert_match(/special.com$/, user.email)
+  end
 end


### PR DESCRIPTION
Instead of email domains all being "@example.com/org/net" it would be nice to make them customizable. This PR adds the ability to do that. Going forward we can add an initializer to our app that will allow us to specify an email domain. That'll look something like:
```ruby
# config/initializers/redaction.rb

Redaction.config.email_domain = "special.com"
```
If a domain is provided to `Redaction.config.email_domain` that will be used when generating the redacted email. So instead of:
```ruby
user = User.last
user.redcat!
user.email
# => "leigh_gorczany@example.net"
```
it will now be something like:
```ruby
user = User.last
user.redcat!
user.email
# => "lorraine_walker@special.com"
```